### PR TITLE
Housekeeping on build script including windows symbol fixes and macos target fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2022, macos-13, ubuntu-22.04]
+        os: [windows-2022, macos-12, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup Choco Packages

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -112,15 +112,14 @@
           </map>
           <key>manifest</key>
           <array>
-            <string>lib/debug/*</string>
             <string>lib/release/*</string>
           </array>
           <key>name</key>
           <string>windows</string>
         </map>
       </map>
-      <key>version_file</key>
-      <string>VERSION.txt</string>
+      <key>use_scm_version</key>
+      <boolean>true</boolean>
     </map>
     <key>type</key>
     <string>autobuild</string>

--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -34,36 +34,34 @@ source "$(dirname "$AUTOBUILD_VARIABLES_FILE")/functions"
 top="$(pwd)"
 stage="$top/stage"
 stage_include="$stage/include/jpeglib"
-stage_debug="$stage/lib/debug"
 stage_release="$stage/lib/release"
 mkdir -p "$stage_include"
-mkdir -p "$stage_debug"
 mkdir -p "$stage_release"
-
-VERSION_HEADER_FILE="$stage_include/jconfig.h"
 
 pushd "$LIBJPEG_TURBO_SOURCE_DIR"
     case "$AUTOBUILD_PLATFORM" in
         windows*)
-            mkdir -p "$stage/lib/debug"
+            opts="$(replace_switch /Zi /Z7 $LL_BUILD_RELEASE)"
+            plainopts="$(remove_switch /GR $(remove_cxxstd $opts))"
+
             mkdir -p "$stage/lib/release"
 
             mkdir -p "build"
             pushd "build"
                 # Invoke cmake and use as official build
-                cmake -G "Ninja Multi-Config" ../ -DWITH_JPEG8=ON -DWITH_CRT_DLL=ON -DWITH_SIMD=ON -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DREQUIRE_SIMD=ON
+                cmake -G "Ninja Multi-Config" ../ \
+                    -DCMAKE_C_FLAGS:STRING="$plainopts" \
+                    -DCMAKE_CXX_FLAGS:STRING="$opts" \
+                    -DWITH_JPEG8=ON -DWITH_CRT_DLL=ON -DWITH_SIMD=ON \
+                    -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DREQUIRE_SIMD=ON
 
-                cmake --build . --config Debug
                 cmake --build . --config Release
 
                 # conditionally run unit tests
-                #if [ "${DISABLE_UNIT_TESTS:-0}" = "0" ]; then
-                #    ctest -C Debug
-                #    ctest -C Release
-                #fi
+                if [ "${DISABLE_UNIT_TESTS:-0}" = "0" ]; then
+                   ctest -C Release
+                fi
 
-                cp -a Debug/jpeg-static.lib "$stage_debug/jpeg.lib"
-                cp -a Debug/turbojpeg-static.lib "$stage_debug/turbojpeg.lib"
                 cp -a Release/jpeg-static.lib "$stage_release/jpeg.lib"
                 cp -a Release/turbojpeg-static.lib "$stage_release/turbojpeg.lib"
 
@@ -76,8 +74,11 @@ pushd "$LIBJPEG_TURBO_SOURCE_DIR"
             cp -a turbojpeg.h "$stage_include"
         ;;
         darwin*)
+            # Setup deploy target
+            export MACOSX_DEPLOYMENT_TARGET="$LL_BUILD_DARWIN_DEPLOY_TARGET"
+
+            # Setup build flags
             opts="${TARGET_OPTS:--arch $AUTOBUILD_CONFIGURE_ARCH $LL_BUILD_RELEASE}"
-            opts="$(set_target $opts)"
             plainopts="$(remove_cxxstd $opts)"
 
             mkdir -p "build_release_x86"
@@ -89,6 +90,7 @@ pushd "$LIBJPEG_TURBO_SOURCE_DIR"
                     -DCMAKE_C_FLAGS="$plainopts" \
                     -DCMAKE_CXX_FLAGS="$opts" \
                     -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64 \
+                    -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
                     -DCMAKE_MACOSX_RPATH=YES \
                     -DCMAKE_INSTALL_PREFIX="$stage/release_x86"
 
@@ -96,9 +98,9 @@ pushd "$LIBJPEG_TURBO_SOURCE_DIR"
                 cmake --install . --config Release
 
                 # conditionally run unit tests
-                # if [ "${DISABLE_UNIT_TESTS:-0}" = "0" ]; then
-                #     ctest -C Release
-                # fi
+                if [ "${DISABLE_UNIT_TESTS:-0}" = "0" ]; then
+                    ctest -C Release
+                fi
             popd
 
             # mkdir -p "build_release_arm64"
@@ -133,21 +135,6 @@ pushd "$LIBJPEG_TURBO_SOURCE_DIR"
             mv $stage/release_x86/include/* $stage_include
         ;;
         linux*)
-            # Linux build environment at Linden comes pre-polluted with stuff that can
-            # seriously damage 3rd-party builds.  Environmental garbage you can expect
-            # includes:
-            #
-            #    DISTCC_POTENTIAL_HOSTS     arch           root        CXXFLAGS
-            #    DISTCC_LOCATION            top            branch      CC
-            #    DISTCC_HOSTS               build_name     suffix      CXX
-            #    LSDISTCC_ARGS              repo           prefix      CFLAGS
-            #    cxx_version                AUTOBUILD      SIGN        CPPFLAGS
-            #
-            # So, clear out bits that shouldn't affect our configure-directed build
-            # but which do nonetheless.
-            #
-            unset DISTCC_HOSTS CFLAGS CPPFLAGS CXXFLAGS
-
             # Default target per --address-size
             opts="${TARGET_OPTS:--m$AUTOBUILD_ADDRSIZE $LL_BUILD_RELEASE}"
             plainopts="$(remove_cxxstd $opts)"
@@ -157,17 +144,18 @@ pushd "$LIBJPEG_TURBO_SOURCE_DIR"
             mkdir -p "build_release"
             pushd "build_release"
                 # Invoke cmake and use as official build
-                cmake -E env CFLAGS="$opts" CXXFLAGS="$opts" \
-                cmake .. -G Ninja -DCMAKE_BUILD_TYPE="Release" -DWITH_JPEG8=ON -DWITH_SIMD=ON -DREQUIRE_SIMD=ON -DENABLE_SHARED=OFF -DENABLE_STATIC=ON \
-                                  -DCMAKE_C_FLAGS="$plainopts" \
-                                  -DCMAKE_CXX_FLAGS="$opts"
+                cmake .. -G Ninja -DCMAKE_BUILD_TYPE="Release" \
+                                -DWITH_JPEG8=ON -DWITH_SIMD=ON -DREQUIRE_SIMD=ON \
+                                -DENABLE_SHARED=OFF -DENABLE_STATIC=ON \
+                                -DCMAKE_C_FLAGS="$plainopts" \
+                                -DCMAKE_CXX_FLAGS="$opts"
 
                 cmake --build . -j$AUTOBUILD_CPU_COUNT --config Release --clean-first
 
                 # conditionally run unit tests
-                # if [ "${DISABLE_UNIT_TESTS:-0}" = "0" ]; then
-                #     ctest -C Release
-                # fi
+                if [ "${DISABLE_UNIT_TESTS:-0}" = "0" ]; then
+                    ctest -C Release
+                fi
 
                 cp -a libjpeg.a "$stage_release/"
                 cp -a libturbojpeg.a "$stage_release/"
@@ -183,13 +171,4 @@ pushd "$LIBJPEG_TURBO_SOURCE_DIR"
     esac
     mkdir -p "$stage/LICENSES"
     cp LICENSE.md "$stage/LICENSES/libjpeg-turbo.txt"
-
-    # version will be (e.g.) "1.4.0"
-    version=`sed -n -E 's/#define LIBJPEG_TURBO_VERSION  ([0-9])[.]([0-9])[.]([0-9]).*/\1.\2.\3/p' "${VERSION_HEADER_FILE}"`
-    # shortver will be (e.g.) "230": eliminate all '.' chars
-    #since the libs do not use micro in their filenames, chop off shortver at minor
-    short="$(echo $version | cut -d"." -f1-2)"
-    shortver="${short//.}"
-
-    echo "${version}" > "${stage}/VERSION.txt"
 popd


### PR DESCRIPTION
* Fix macos targeting to use version from build variables
* Fix windows build to include symbols and utilize build variables
* Remove obsolete windows debug build
* Update to use scm versioning
* General script fixes and cleanup